### PR TITLE
Fixed bug when opening installation properties window

### DIFF
--- a/opsi-admin-core/src/main/java/cz/muni/ucn/opsi/core/opsiClient/OpsiClientServiceImpl.java
+++ b/opsi-admin-core/src/main/java/cz/muni/ucn/opsi/core/opsiClient/OpsiClientServiceImpl.java
@@ -269,8 +269,12 @@ public class OpsiClientServiceImpl implements OpsiClientService, InitializingBea
 		List<Map<String,Object>> result = (List<Map<String, Object>>) response.getResult();
 		List<ProductPropertyState> l = new ArrayList<ProductPropertyState>(result.size());
 		for (Map<String, Object> pmap : result) {
-			l.add(new ProductPropertyState((String) pmap.get("objectId"), (String) pmap.get("productId"),
-					(String) pmap.get("propertyId"), (List<String>)pmap.get("values")
+			List<String> values = new ArrayList<String>();
+			for (Object obj : pmap.values()) {
+				values.add(obj != null ? obj.toString() : null);
+			}
+			l.add(new ProductPropertyState(pmap.get("objectId").toString(), pmap.get("productId").toString(),
+					pmap.get("propertyId").toString(), values
 					));
 		}
 		return l;


### PR DESCRIPTION
There was exception about casting boolean to string when retrieving info about installation properties, making the application unusable in Google Chrome web browser.
![opsi-admin-bug](https://cloud.githubusercontent.com/assets/5710409/15643906/247c0fba-2650-11e6-9d38-dcb6e3dc1fcd.png)
